### PR TITLE
Suppress Twind warnings

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,8 @@ module.exports = {
   stories: ["../src/**/*.stories.tsx"],
   addons: [
     "@storybook/addon-essentials",
-    "@storybook/addon-console"
+    "@storybook/addon-console",
+    "@storybook/addon-knobs",
   ],
   core: {
     builder: "webpack5",

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,6 @@ module.exports = {
   stories: ["../src/**/*.stories.tsx"],
   addons: [
     "@storybook/addon-essentials",
-    "@storybook/addon-actions",
     "@storybook/addon-console"
   ],
   core: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,10 +2,7 @@ import "@storybook/addon-actions/register";
 import { addDecorator } from "@storybook/react";
 import { withConsole } from "@storybook/addon-console";
 
-// Install twind
-import { install } from "@twind/core"
-import twindConfig from "../twind.config"
-install(twindConfig)
+import "../twind.install"
 
 addDecorator((storyFn, context) => withConsole()(storyFn)(context));
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,12 @@
 import "@storybook/addon-actions/register";
 import { addDecorator } from "@storybook/react";
 import { withConsole } from "@storybook/addon-console";
+import { withKnobs } from '@storybook/addon-knobs';
 
 import "../twind.install"
 
+// Add decorators
+addDecorator(withKnobs);
 addDecorator((storyFn, context) => withConsole()(storyFn)(context));
 
 export const parameters = {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tiptap/extension-character-count": "^2.0.0-beta.31",
     "@tiptap/react": "^2.0.0-beta.114",
     "@tiptap/starter-kit": "^2.0.0-beta.191",
-    "@twind/core": "^1.0.1",
+    "@twind/core": "^1.0.3",
     "@twind/forms": "^0.1.4",
     "@twind/preset-autoprefix": "^1.0.1",
     "@twind/preset-tailwind": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",
     "@faker-js/faker": "^7.5.0",
-    "@storybook/addon-actions": "6.5.14",
     "@storybook/addon-console": "1.2.3",
     "@storybook/addon-essentials": "6.5.14",
     "@storybook/builder-webpack5": "6.5.14",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@faker-js/faker": "^7.5.0",
     "@storybook/addon-console": "1.2.3",
     "@storybook/addon-essentials": "6.5.14",
+    "@storybook/addon-knobs": "^6.4.0",
     "@storybook/builder-webpack5": "6.5.14",
     "@storybook/manager-webpack5": "6.5.14",
     "@storybook/react": "6.5.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,6 @@ specifiers:
   '@babel/preset-typescript': ^7.18.6
   '@faker-js/faker': ^7.5.0
   '@headlessui/react': 1.6.6
-  '@storybook/addon-actions': 6.5.14
   '@storybook/addon-console': 1.2.3
   '@storybook/addon-essentials': 6.5.14
   '@storybook/builder-webpack5': 6.5.14
@@ -75,8 +74,7 @@ dependencies:
 devDependencies:
   '@babel/preset-typescript': 7.18.6
   '@faker-js/faker': 7.5.0
-  '@storybook/addon-actions': 6.5.14_biqbaboplfbrettd7655fr4n2y
-  '@storybook/addon-console': 1.2.3_473b6rbrlfbkiblbxydosemc4u
+  '@storybook/addon-console': 1.2.3
   '@storybook/addon-essentials': 6.5.14_reageqapiqqt4xknybmptuy454
   '@storybook/builder-webpack5': 6.5.14_gnpjyu2zpng3ocit5qjrsgv23u
   '@storybook/manager-webpack5': 6.5.14_gnpjyu2zpng3ocit5qjrsgv23u
@@ -3002,12 +3000,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-console/1.2.3_473b6rbrlfbkiblbxydosemc4u:
+  /@storybook/addon-console/1.2.3:
     resolution: {integrity: sha512-w5uCUwECA28fdZWoa+A4e/RS9XzBStdd3TwwmpSM5m4fjURJI7Qr+uVq30UeRdgZRH1K7CdWzYUE6RxWXMdVyw==}
     peerDependencies:
       '@storybook/addon-actions': '*'
     dependencies:
-      '@storybook/addon-actions': 6.5.14_biqbaboplfbrettd7655fr4n2y
       global: 4.4.0
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   '@tiptap/extension-character-count': ^2.0.0-beta.31
   '@tiptap/react': ^2.0.0-beta.114
   '@tiptap/starter-kit': ^2.0.0-beta.191
-  '@twind/core': ^1.0.1
+  '@twind/core': ^1.0.3
   '@twind/forms': ^0.1.4
   '@twind/preset-autoprefix': ^1.0.1
   '@twind/preset-tailwind': ^1.0.1
@@ -56,10 +56,10 @@ dependencies:
   '@tiptap/extension-character-count': 2.0.0-beta.31
   '@tiptap/react': 2.0.0-beta.114_biqbaboplfbrettd7655fr4n2y
   '@tiptap/starter-kit': 2.0.0-beta.191
-  '@twind/core': 1.0.1_typescript@4.7.4
+  '@twind/core': 1.0.3_typescript@4.7.4
   '@twind/forms': 0.1.4_typescript@4.7.4
-  '@twind/preset-autoprefix': 1.0.1_xxnsjm5yl6nod3pjzwnerjadou
-  '@twind/preset-tailwind': 1.0.1_xxnsjm5yl6nod3pjzwnerjadou
+  '@twind/preset-autoprefix': 1.0.1_fjozfkeae7halryerxuhkgafou
+  '@twind/preset-tailwind': 1.0.1_fjozfkeae7halryerxuhkgafou
   '@twind/typography': 0.0.2_typescript@4.7.4
   class-variance-authority: 0.3.0_typescript@4.7.4
   date-fns: 2.29.1
@@ -4960,8 +4960,8 @@ packages:
     engines: {node: '>= 10'}
     dev: true
 
-  /@twind/core/1.0.1_typescript@4.7.4:
-    resolution: {integrity: sha512-cSiDmTqSZ3HYqhbUhb9r//EiYvdfzteU9qbIPeBCIUkNg3ZUol4vOYNxBH5ymmderF4pvQ+Btf6d+flpVm0U9g==}
+  /@twind/core/1.0.3_typescript@4.7.4:
+    resolution: {integrity: sha512-0YC4H04tcvYC1McELC3jHykXGxK1n5AC/pQhP/gaz4LcZkAEl3sP37/+/duBUBFJBPZ11Z8DD2hSAU/em+9aWA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       typescript: ^4.8.4
@@ -4969,7 +4969,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@swc/helpers': 0.4.14
       csstype: 3.1.1
       typescript: 4.7.4
     dev: false
@@ -4987,7 +4986,7 @@ packages:
       typescript: 4.7.4
     dev: false
 
-  /@twind/preset-autoprefix/1.0.1_xxnsjm5yl6nod3pjzwnerjadou:
+  /@twind/preset-autoprefix/1.0.1_fjozfkeae7halryerxuhkgafou:
     resolution: {integrity: sha512-UL/09ZjK+lw07i12czrQZgQTznNnfsLZXlRjfxx9Tl76O7uv2Z41Ws2jl6/ONbwbtcC9t+xslZWm/i4KbfaD+w==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -4997,12 +4996,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@twind/core': 1.0.1_typescript@4.7.4
+      '@twind/core': 1.0.3_typescript@4.7.4
       style-vendorizer: 2.2.3
       typescript: 4.7.4
     dev: false
 
-  /@twind/preset-tailwind/1.0.1_xxnsjm5yl6nod3pjzwnerjadou:
+  /@twind/preset-tailwind/1.0.1_fjozfkeae7halryerxuhkgafou:
     resolution: {integrity: sha512-anUOpxjvKFvxi4jP3u0HgP1+GtnqMFR7bZOUUc8+M099zIyLaRtBWw/8CCn+QN1WY/eZ01e7ru8GlYPUpJEQxA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -5013,7 +5012,7 @@ packages:
         optional: true
     dependencies:
       '@swc/helpers': 0.4.14
-      '@twind/core': 1.0.1_typescript@4.7.4
+      '@twind/core': 1.0.3_typescript@4.7.4
       typescript: 4.7.4
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@headlessui/react': 1.6.6
   '@storybook/addon-console': 1.2.3
   '@storybook/addon-essentials': 6.5.14
+  '@storybook/addon-knobs': ^6.4.0
   '@storybook/builder-webpack5': 6.5.14
   '@storybook/manager-webpack5': 6.5.14
   '@storybook/react': 6.5.14
@@ -76,6 +77,7 @@ devDependencies:
   '@faker-js/faker': 7.5.0
   '@storybook/addon-console': 1.2.3
   '@storybook/addon-essentials': 6.5.14_reageqapiqqt4xknybmptuy454
+  '@storybook/addon-knobs': 6.4.0_biqbaboplfbrettd7655fr4n2y
   '@storybook/builder-webpack5': 6.5.14_gnpjyu2zpng3ocit5qjrsgv23u
   '@storybook/manager-webpack5': 6.5.14_gnpjyu2zpng3ocit5qjrsgv23u
   '@storybook/react': 6.5.14_drgzilfurcuzzainecsrd5kjo4
@@ -2415,6 +2417,75 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
+  /@emotion/cache/10.0.29:
+    resolution: {integrity: sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==}
+    dependencies:
+      '@emotion/sheet': 0.9.4
+      '@emotion/stylis': 0.8.5
+      '@emotion/utils': 0.11.3
+      '@emotion/weak-memoize': 0.2.5
+    dev: true
+
+  /@emotion/core/10.3.1_react@18.2.0:
+    resolution: {integrity: sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==}
+    peerDependencies:
+      react: '>=16.3.0'
+    dependencies:
+      '@babel/runtime': 7.18.9
+      '@emotion/cache': 10.0.29
+      '@emotion/css': 10.0.27
+      '@emotion/serialize': 0.11.16
+      '@emotion/sheet': 0.9.4
+      '@emotion/utils': 0.11.3
+      react: 18.2.0
+    dev: true
+
+  /@emotion/css/10.0.27:
+    resolution: {integrity: sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==}
+    dependencies:
+      '@emotion/serialize': 0.11.16
+      '@emotion/utils': 0.11.3
+      babel-plugin-emotion: 10.2.2
+    dev: true
+
+  /@emotion/hash/0.8.0:
+    resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
+    dev: true
+
+  /@emotion/memoize/0.7.4:
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    dev: true
+
+  /@emotion/serialize/0.11.16:
+    resolution: {integrity: sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==}
+    dependencies:
+      '@emotion/hash': 0.8.0
+      '@emotion/memoize': 0.7.4
+      '@emotion/unitless': 0.7.5
+      '@emotion/utils': 0.11.3
+      csstype: 2.6.21
+    dev: true
+
+  /@emotion/sheet/0.9.4:
+    resolution: {integrity: sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==}
+    dev: true
+
+  /@emotion/stylis/0.8.5:
+    resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
+    dev: true
+
+  /@emotion/unitless/0.7.5:
+    resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
+    dev: true
+
+  /@emotion/utils/0.11.3:
+    resolution: {integrity: sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==}
+    dev: true
+
+  /@emotion/weak-memoize/0.2.5:
+    resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
+    dev: true
+
   /@faker-js/faker/7.5.0:
     resolution: {integrity: sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
@@ -3180,6 +3251,38 @@ packages:
       - vue-template-compiler
       - webpack-cli
       - webpack-command
+    dev: true
+
+  /@storybook/addon-knobs/6.4.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-DiH1/5e2AFHoHrncl1qLu18ZHPHzRMMPvOLFz8AWvvmc+VCqTdIaE+tdxKr3e8rYylKllibgvDOzrLjfTNjF+Q==}
+    deprecated: deprecating @storybook/addon-knobs in favor of @storybook/addon-controls
+    peerDependencies:
+      '@storybook/addons': ^6.4.0
+      '@storybook/api': ^6.4.0
+      '@storybook/components': ^6.4.0
+      '@storybook/core-events': ^6.4.0
+      '@storybook/theming': ^6.4.0
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      copy-to-clipboard: 3.3.3
+      core-js: 3.24.1
+      escape-html: 1.0.3
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      qs: 6.11.0
+      react: 18.2.0
+      react-colorful: 5.6.1_biqbaboplfbrettd7655fr4n2y
+      react-dom: 18.2.0_react@18.2.0
+      react-lifecycles-compat: 3.0.4
+      react-select: 3.2.0_biqbaboplfbrettd7655fr4n2y
     dev: true
 
   /@storybook/addon-measure/6.5.14_biqbaboplfbrettd7655fr4n2y:
@@ -5941,6 +6044,21 @@ packages:
     dependencies:
       object.assign: 4.1.3
 
+  /babel-plugin-emotion/10.2.2:
+    resolution: {integrity: sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==}
+    dependencies:
+      '@babel/helper-module-imports': 7.18.6
+      '@emotion/hash': 0.8.0
+      '@emotion/memoize': 0.7.4
+      '@emotion/serialize': 0.11.16
+      babel-plugin-macros: 2.8.0
+      babel-plugin-syntax-jsx: 6.18.0
+      convert-source-map: 1.8.0
+      escape-string-regexp: 1.0.5
+      find-root: 1.1.0
+      source-map: 0.5.7
+    dev: true
+
   /babel-plugin-extract-import-names/1.6.22:
     resolution: {integrity: sha512-yJ9BsJaISua7d8zNT7oRG1ZLBJCIdZ4PZqmH8qa9N5AK01ifk3fnkc98AXhtzE7UkfCsEumvoQWgoYLhOnJ7jQ==}
     dependencies:
@@ -5967,6 +6085,14 @@ packages:
       '@babel/types': 7.18.10
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.18.0
+    dev: true
+
+  /babel-plugin-macros/2.8.0:
+    resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
+    dependencies:
+      '@babel/runtime': 7.18.9
+      cosmiconfig: 6.0.0
+      resolve: 1.22.1
     dev: true
 
   /babel-plugin-macros/3.1.0:
@@ -6066,6 +6192,10 @@ packages:
       react-docgen: 5.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /babel-plugin-syntax-jsx/6.18.0:
+    resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
     dev: true
 
   /babel-preset-current-node-syntax/1.0.1:
@@ -6874,6 +7004,12 @@ packages:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
     engines: {node: '>=0.10.0'}
 
+  /copy-to-clipboard/3.3.3:
+    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
+    dependencies:
+      toggle-selection: 1.0.6
+    dev: true
+
   /core-js-compat/3.24.1:
     resolution: {integrity: sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==}
     dependencies:
@@ -7091,6 +7227,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       cssom: 0.3.8
+    dev: true
+
+  /csstype/2.6.21:
+    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
     dev: true
 
   /csstype/3.1.0:
@@ -7346,6 +7486,13 @@ packages:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
     dependencies:
       utila: 0.4.0
+    dev: true
+
+  /dom-helpers/5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.18.9
+      csstype: 3.1.1
     dev: true
 
   /dom-serializer/1.4.1:
@@ -7961,6 +8108,10 @@ packages:
       commondir: 1.0.1
       make-dir: 3.1.0
       pkg-dir: 4.2.0
+
+  /find-root/1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+    dev: true
 
   /find-up/1.1.2:
     resolution: {integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==}
@@ -10358,6 +10509,10 @@ packages:
     dependencies:
       fs-monkey: 1.0.3
 
+  /memoize-one/5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+    dev: true
+
   /memoizerific/1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
     dependencies:
@@ -11813,6 +11968,16 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
+  /react-colorful/5.6.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: true
+
   /react-docgen-typescript/2.2.2_typescript@4.7.4:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
@@ -11879,6 +12044,15 @@ packages:
       react: 18.2.0
     dev: false
 
+  /react-input-autosize/3.0.0_react@18.2.0:
+    resolution: {integrity: sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==}
+    peerDependencies:
+      react: ^16.3.0 || ^17.0.0
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.2.0
+    dev: true
+
   /react-inspector/5.1.1_react@18.2.0:
     resolution: {integrity: sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==}
     peerDependencies:
@@ -11902,6 +12076,10 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
+  /react-lifecycles-compat/3.0.4:
+    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+    dev: true
+
   /react-refresh/0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
     engines: {node: '>=0.10.0'}
@@ -11916,6 +12094,38 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
+
+  /react-select/3.2.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.18.9
+      '@emotion/cache': 10.0.29
+      '@emotion/core': 10.3.1_react@18.2.0
+      '@emotion/css': 10.0.27
+      memoize-one: 5.2.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-input-autosize: 3.0.0_react@18.2.0
+      react-transition-group: 4.4.5_biqbaboplfbrettd7655fr4n2y
+    dev: true
+
+  /react-transition-group/4.4.5_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.18.9
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: true
 
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -13179,6 +13389,10 @@ packages:
       extend-shallow: 3.0.2
       regex-not: 1.0.2
       safe-regex: 1.1.0
+
+  /toggle-selection/1.0.6:
+    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+    dev: true
 
   /toidentifier/1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}

--- a/src/ui/design/Button/Button.stories.tsx
+++ b/src/ui/design/Button/Button.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory } from "@storybook/react";
 import { story } from "@storybook-util";
+import { text } from "@storybook/addon-knobs";
 
 import { Button } from "./Button";
 
@@ -11,7 +12,7 @@ export default {
 };
 
 const Template: ComponentStory<typeof Button> = (args) => (
-  <Button {...args}>Button</Button>
+  <Button {...args}>{text("label", "Button")}</Button>
 );
 
 export const Primary = Template.bind({});

--- a/twind.install.js
+++ b/twind.install.js
@@ -8,7 +8,7 @@ addEventListener('warning', (event) => {
 
   const warning = event.detail
 
-  // Skip warning for storybook classes
+  // Skip warnings for css classes from Storybook
   if (warning.code === "TWIND_INVALID_CLASS" && warning.detail.startsWith("sb-")) {
     return
   }

--- a/twind.install.js
+++ b/twind.install.js
@@ -1,0 +1,21 @@
+import { install } from "@twind/core"
+import config from "./twind.config"
+
+// Override `warning` event from Twind to suppress false warnings.
+// This override need to run before installing twind (`install(config)`).
+addEventListener('warning', (event) => {
+  event.preventDefault()
+
+  const warning = event.detail
+
+  // Skip warning for storybook classes
+  if (warning.code === "TWIND_INVALID_CLASS" && warning.detail.startsWith("sb-")) {
+    return
+  }
+
+  // { message: '...', code: 'TWIND_INVALID_CLASS', detail: '<className>'}
+  // { message: '...', code: 'TWIND_INVALID_CSS', detail: '<css>'}
+  console.warn(warning.message)
+})
+
+install(config)


### PR DESCRIPTION
### What
Suppress Twind warnings for storybook css classes. Also installed `@storybook/addon-knobs` to allow exploration on elements that are not exposed as props.

### Why
Remove clutter and prevent the false warnings from masking the actual cases.

### Screenshots
![image](https://user-images.githubusercontent.com/7823011/206574042-cc54d011-efae-4294-ac5c-cd0522f95a77.png)

### Test Plan
- Twind warnings shouldn't show up in "Actions" tab

### Checklist
- [x] I have self-reviewed the changes and added explanatory comments as needed
