### PR TITLE
Add winbox demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/react-dom": "18.0.6",
     "babel-jest": "28.1.3",
     "fishery": "^2.2.2",
+    "identity-obj-proxy": "^3.0.0",
     "isomorphic-unfetch": "^3.1.0",
     "jest": "28.1.3",
     "jest-environment-jsdom": "28.1.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "react-hook-form": "^7.34.0",
     "react-icons": "^4.4.0",
     "react-script-hook": "^1.7.2",
+    "react-winbox": "^1.4.2",
     "storybook": "6.5.14",
+    "ts-pattern": "^4.0.6",
     "zod": "^3.18.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ specifiers:
   date-fns: ^2.29.1
   fishery: ^2.2.2
   gantt-task-react: ^0.3.9
+  identity-obj-proxy: ^3.0.0
   isomorphic-unfetch: ^3.1.0
   jest: 28.1.3
   jest-environment-jsdom: 28.1.3
@@ -95,6 +96,7 @@ devDependencies:
   '@types/react-dom': 18.0.6
   babel-jest: 28.1.3
   fishery: 2.2.2
+  identity-obj-proxy: 3.0.0
   isomorphic-unfetch: 3.1.0
   jest: 28.1.3
   jest-environment-jsdom: 28.1.3
@@ -8447,6 +8449,10 @@ packages:
     optionalDependencies:
       uglify-js: 3.16.3
 
+  /harmony-reflect/1.6.2:
+    resolution: {integrity: sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==}
+    dev: true
+
   /has-bigints/1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: true
@@ -8778,6 +8784,13 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.16
+    dev: true
+
+  /identity-obj-proxy/3.0.0:
+    resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
+    engines: {node: '>=4'}
+    dependencies:
+      harmony-reflect: 1.6.2
     dev: true
 
   /ieee754/1.2.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,10 @@ specifiers:
   react-hook-form: ^7.34.0
   react-icons: ^4.4.0
   react-script-hook: ^1.7.2
+  react-winbox: ^1.4.2
   storybook: 6.5.14
   ts-jest: 28.0.7
+  ts-pattern: ^4.0.6
   tsconfig-paths: ^4.1.0
   tsconfig-paths-webpack-plugin: 4.0.0
   typescript: 4.7.4
@@ -68,7 +70,9 @@ dependencies:
   react-hook-form: 7.34.0_react@18.2.0
   react-icons: 4.4.0_react@18.2.0
   react-script-hook: 1.7.2_biqbaboplfbrettd7655fr4n2y
+  react-winbox: 1.4.2_biqbaboplfbrettd7655fr4n2y
   storybook: 6.5.14_xrxvbtylmve4l2tr3vmmqgfp7q
+  ts-pattern: 4.0.6
   zod: 3.18.0
 
 devDependencies:
@@ -11916,6 +11920,17 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
+  /react-winbox/1.4.2_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-wNe3Ug6ZLiq1Mxk4CCUWtuR3xX2EPYqijtg83Dh/r6cP5zHFzTersmNPLNffOCRLMxlMsUvx0VNaID/7KbleBg==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      winbox: 0.2.6
+    dev: false
+
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -13255,6 +13270,10 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
+  /ts-pattern/4.0.6:
+    resolution: {integrity: sha512-sFHQYD4KoysBi7e7a2mzDPvRBeqA4w+vEyRE+P5MU9VLq8eEYxgKCgD9RNEAT+itGRWUTYN+hry94GDPLb1/Yw==}
+    dev: false
+
   /ts-pnp/1.2.0_typescript@4.7.4:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
@@ -13932,6 +13951,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       string-width: 4.2.3
+
+  /winbox/0.2.6:
+    resolution: {integrity: sha512-P/Tqjcf4bA0Hr1lqR1YliQsisV8xf+t56xgCtqWN8Urw9RLonYSVQGYw+qILp9tgkPs1o7e1dsl6dskaS6GudQ==}
+    dev: false
 
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -1,13 +1,15 @@
 const fs = require("fs")
 
-const componentName = process.argv[2]
+const splitArg = process.argv[2].split("/");
+const path = splitArg.slice(0, -1).join("/");
+const componentName = splitArg.pop();
 if (!componentName) {
-  console.log("Usage: yarn create-component {ComponentName}")
-  console.log("Example: yarn create-component MyComponent")
+  console.log("Usage: pnpm create-component {path/ComponentName}")
+  console.log("Example: pnpm create-component components/MyButton")
   process.exit(1)
 }
 
-const dir = `./src/components/${componentName}`
+const dir = `./src/${path}/${componentName}`
 if (fs.existsSync(dir)) {
   console.log("Error: component already exists")
   console.log("→", dir)
@@ -20,26 +22,35 @@ fs.mkdirSync(dir)
 
 const templates = {
   "index.ts": `export * from "./${componentName}"\n`,
-  [`${componentName}.tsx`]: `import { cx } from "@twind/core"
+  [`${componentName}.tsx`]: `import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 
-const base = {
-  container: "flex",
-}
+type Variants = VariantProps<typeof style>;
+export type ${componentName}Props = Variants & {
+  children: React.ReactNode;
+};
 
-const colors = {
-  red: "text-red-500",
-  green: "text-green-500",
-}
+export const style = cva(
+  ["text-white"],
+  {
+    variants: {
+      intent: {
+        basic: "bg-gray-400",
+      },
+    },
+    defaultVariants: {
+      intent: "basic",
+    },
+  }
+);
 
-type Props = {
-  children: React.ReactNode
-  color?: keyof typeof colors
-  styles?: StyleOverride<typeof base>
-}
-
-export const ${componentName} = ({ children, color = "red", styles }: Props) => {
-  return <div className={cx(base.container, styles?.container, colors[color])}>{children}</div>
-}
+export const ${componentName} = ({ children, ...variants }: ${componentName}Props) => {
+  return (
+    <div className={style(variants)}>
+      {children}
+    </div>
+  );
+};
 `,
   [`${componentName}.test.tsx`]: `import { render } from "@test"
 import { ${componentName} } from "."
@@ -55,12 +66,26 @@ describe("${componentName}", () => {
   })
 })
 `,
-  [`${componentName}.stories.tsx`]: `import { story } from "@storybook-util"
-import { ${componentName} } from "."
+  [`${componentName}.stories.tsx`]: `import { story, ComponentStory } from "@storybook-util";
 
-export default story(${componentName})
+import { ${componentName} } from "./${componentName}";
 
-export const Basic = () => <${componentName}>Hello world!</${componentName}>
+export default {
+  ...story(${componentName}, { path: "ui/design" }),
+  argTypes: {
+    rounded: { control: "boolean" },
+  },
+  args: {
+    _label: "${componentName}",
+  },
+};
+
+const Template: ComponentStory<typeof ${componentName}> = (args) => (
+  <${componentName} {...args}>{args._label}</${componentName}>
+);
+
+export const Basic = Template.bind({});
+Basic.args = { intent: "basic" };
 `,
 }
 

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -72,9 +72,6 @@ import { ${componentName} } from "./${componentName}";
 
 export default {
   ...story(${componentName}, { path: "ui/design" }),
-  argTypes: {
-    rounded: { control: "boolean" },
-  },
   args: {
     _label: "${componentName}",
   },

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -71,7 +71,7 @@ describe("${componentName}", () => {
 import { ${componentName} } from "./${componentName}";
 
 export default {
-  ...story(${componentName}, { path: "ui/design" }),
+  ...story(${componentName}, { path: "${path}" }),
   args: {
     _label: "${componentName}",
   },

--- a/src/components/⛵️ Exploration/Unfeed/Unfeed.stories.tsx
+++ b/src/components/⛵️ Exploration/Unfeed/Unfeed.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory } from "@storybook/react";
 import { story } from "@storybook-util";
-import { button } from "@ui/design";
+import { style as button } from "@ui/design/Button";
 
 import { Unfeed, defaultSrc } from "./Unfeed";
 

--- a/src/components/⛵️ Exploration/Winbox/Winbox.stories.tsx
+++ b/src/components/⛵️ Exploration/Winbox/Winbox.stories.tsx
@@ -1,0 +1,11 @@
+import { story, ComponentStory } from "@storybook-util";
+
+import { Winbox } from "./Winbox";
+
+export default {
+  ...story(Winbox, { path: "ui/design" }),
+};
+
+const Template: ComponentStory<typeof Winbox> = (args) => <Winbox {...args} />;
+
+export const Demo = Template.bind({});

--- a/src/components/⛵️ Exploration/Winbox/Winbox.stories.tsx
+++ b/src/components/⛵️ Exploration/Winbox/Winbox.stories.tsx
@@ -3,7 +3,7 @@ import { story, ComponentStory } from "@storybook-util";
 import { Winbox } from "./Winbox";
 
 export default {
-  ...story(Winbox, { path: "ui/design" }),
+  ...story(Winbox, { path: "components/⛵️ Exploration" }),
 };
 
 const Template: ComponentStory<typeof Winbox> = (args) => <Winbox {...args} />;

--- a/src/components/⛵️ Exploration/Winbox/Winbox.test.tsx
+++ b/src/components/⛵️ Exploration/Winbox/Winbox.test.tsx
@@ -1,0 +1,13 @@
+import { render } from "@test"
+import { Winbox } from "."
+
+describe("Winbox", () => {
+  const props = {
+    children: "Hello world!",
+  }
+  it("renders without error", () => {
+    const { getByText } = render(<Winbox>{props.children}</Winbox>)
+
+    expect(getByText(props.children)).toBeInTheDocument()
+  })
+})

--- a/src/components/⛵️ Exploration/Winbox/Winbox.test.tsx
+++ b/src/components/⛵️ Exploration/Winbox/Winbox.test.tsx
@@ -1,13 +1,8 @@
-import { render } from "@test"
-import { Winbox } from "."
+import { render } from "@test";
+import { Winbox } from ".";
 
 describe("Winbox", () => {
-  const props = {
-    children: "Hello world!",
-  }
   it("renders without error", () => {
-    const { getByText } = render(<Winbox>{props.children}</Winbox>)
-
-    expect(getByText(props.children)).toBeInTheDocument()
-  })
-})
+    render(<Winbox />);
+  });
+});

--- a/src/components/⛵️ Exploration/Winbox/Winbox.tsx
+++ b/src/components/⛵️ Exploration/Winbox/Winbox.tsx
@@ -1,0 +1,107 @@
+import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+import { useState } from "react";
+import WinBox, { WinBoxPropType } from "react-winbox";
+import { Button } from "@ui/design/Button";
+import { Link } from "@ui/design/Link";
+import { P } from "@ui/typography/Paragraph";
+
+type Variants = VariantProps<typeof style>;
+export type WinboxProps = Variants & {
+  children: React.ReactNode;
+};
+
+export const style = cva([], {});
+
+export const Winbox = ({ children, ...variants }: WinboxProps) => {
+  const baseProps = {
+    x: "center",
+    y: "center",
+  };
+  const [windows, setWindows] = useState<WinBoxPropType[]>([
+    {
+      ...baseProps,
+      id: "1",
+      title: "Window 1 – use `icon` prop to show icon",
+      icon: "https://icongr.am/feather/calendar.svg?size=128&color=ffffff",
+    },
+    {
+      ...baseProps,
+      id: "2",
+      title: "Window 2 – use `url` prop to load example.com in iframe",
+      url: "https://example.com",
+      width: "50%",
+      height: "50%",
+    },
+    {
+      ...baseProps,
+      id: "3",
+      title: "Window 3 – custom children",
+      children: (
+        <div className="h-full grid justify-center items-center text-lg text-blue-500">
+          Hello world!
+        </div>
+      ),
+    },
+    {
+      ...baseProps,
+      id: "4",
+      title: "Window 4 – no shadow",
+      noShadow: true,
+    },
+  ]);
+
+  // State to determine if window is opened
+  const [isWindowOpen, setIsWindowOpen] = useState<Record<string, boolean>>({});
+
+  const handleClose = (force: boolean, windowId: string) => {
+    setIsWindowOpen((state) => ({ ...state, [windowId]: false }));
+  };
+
+  const handleOpenWindow = (windowId: number) => {
+    setIsWindowOpen((state) => ({ ...state, [windowId]: true }));
+  };
+
+  return (
+    <div>
+      <P>
+        This is a demo of Winbox in React.{" "}
+        <Link href="https://github.com/nextapps-de/winbox">Winbox library</Link>{" "}
+        is framework-agnostic. This demo uses{" "}
+        <Link
+          href="https://github.com/rickonono3/react-winbox"
+          format="github"
+        />{" "}
+        which wraps Winbox library in React.
+        <br />
+        Click the button to open a window:
+      </P>
+      <br />
+      <div>
+        <ol className="grid gap-3">
+          {windows.map((window, i) => (
+            <li key={window.id}>
+              <Button onClick={() => handleOpenWindow(window.id)}>
+                {window.title}
+              </Button>
+            </li>
+          ))}
+        </ol>
+      </div>
+      <br />
+
+      {windows.map(({ id, ...props }) =>
+        isWindowOpen[id] ? (
+          <WinBox
+            key={id}
+            id={id}
+            onclose={(force) => handleClose(force, id)}
+            {...props} // assign any props you want to WinBox
+          >
+            {props.children || <div>Some children</div>}
+          </WinBox>
+        ) : null
+      )}
+    </div>
+  );
+};

--- a/src/components/⛵️ Exploration/Winbox/Winbox.tsx
+++ b/src/components/⛵️ Exploration/Winbox/Winbox.tsx
@@ -7,13 +7,11 @@ import { Link } from "@ui/design/Link";
 import { P } from "@ui/typography/Paragraph";
 
 type Variants = VariantProps<typeof style>;
-export type WinboxProps = Variants & {
-  children: React.ReactNode;
-};
+export type WinboxProps = Variants & {};
 
 export const style = cva([], {});
 
-export const Winbox = ({ children, ...variants }: WinboxProps) => {
+export const Winbox = ({ ...variants }: WinboxProps) => {
   const baseProps = {
     x: "center",
     y: "center",

--- a/src/components/⛵️ Exploration/Winbox/index.ts
+++ b/src/components/⛵️ Exploration/Winbox/index.ts
@@ -1,0 +1,1 @@
+export * from "./Winbox"

--- a/src/ui/design/Button/Button.tsx
+++ b/src/ui/design/Button/Button.tsx
@@ -1,21 +1,13 @@
 import type { VariantProps } from "class-variance-authority";
 import { cva } from "class-variance-authority";
 
-type ButtonVariants = VariantProps<typeof button>;
-export type ButtonProps = ButtonVariants & {
+type Variants = VariantProps<typeof style>;
+export type ButtonProps = Variants & {
   children?: JSX.Element | string;
   onClick?: () => void;
 };
 
-export const Button = ({ children, onClick, ...variants }: ButtonProps) => {
-  return (
-    <button type="button" className={button(variants)} onClick={onClick}>
-      {children}
-    </button>
-  );
-};
-
-export const button = cva(
+export const style = cva(
   [
     "rounded font-medium shadow-sm text-white",
     "items-center inline-flex",
@@ -45,3 +37,11 @@ export const button = cva(
     },
   }
 );
+
+export const Button = ({ children, onClick, ...variants }: ButtonProps) => {
+  return (
+    <button type="button" className={style(variants)} onClick={onClick}>
+      {children}
+    </button>
+  );
+};

--- a/src/ui/design/Link/Link.tsx
+++ b/src/ui/design/Link/Link.tsx
@@ -1,0 +1,40 @@
+import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+import { match, P } from "ts-pattern";
+import { AiFillGithub } from "react-icons/ai";
+
+type Variants = VariantProps<typeof style>;
+export type LinkProps = Variants &
+  HTMLLinkElement & {
+    children?: JSX.Element | string;
+  };
+
+export const style = cva(["text-blue-600"], {
+  variants: {
+    format: {
+      short: "",
+      github: "",
+    },
+  },
+  defaultVariants: {
+    format: "short",
+  },
+});
+
+export const Link = ({ children, href, target, ...variants }: LinkProps) => {
+  return (
+    <a className={style(variants)} href={href} target={target}>
+      {match(variants)
+        .with({ format: P.nullish }, { format: "short" }, () =>
+          href.split("//").pop()
+        )
+        .with({ format: "github" }, () => (
+          <>
+            <AiFillGithub className="inline mr-0.5 align-middle" />
+            {href.split("github.com/").pop()}
+          </>
+        ))
+        .otherwise(() => children)}
+    </a>
+  );
+};

--- a/src/ui/design/Link/index.tsx
+++ b/src/ui/design/Link/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Link";

--- a/src/ui/typography/Paragraph.tsx
+++ b/src/ui/typography/Paragraph.tsx
@@ -1,0 +1,16 @@
+import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+
+type Variants = VariantProps<typeof style>;
+export type ParagraphProps = Variants & {
+  children: JSX.Element | string;
+};
+
+export const style = cva(["text-gray-900 dark:text-gray-300"]);
+
+export const Paragraph = ({ children }: ParagraphProps) => (
+  <p className={style()}>{children}</p>
+);
+
+// Short alias for Paragraph
+export const P = Paragraph;

--- a/twind.config.js
+++ b/twind.config.js
@@ -3,5 +3,6 @@ import presetAutoprefix from '@twind/preset-autoprefix'
 import presetTailwind from '@twind/preset-tailwind'
 
 export default defineConfig({
+  darkMode: 'class',
   presets: [presetAutoprefix(), presetTailwind()],
 })


### PR DESCRIPTION
### What

- added demo for winbox (https://github.com/nextapps-de/winbox)
- added new ui components: design/Link, typography/Paragraph
- updated create-component script to use cva

URL (available once PR is merged):
https://unwind.design/?path=/story/components-⛵%EF%B8%8F-exploration-winbox--demo

### Why
I want to know what I can do with winbox

### Preview

https://user-images.githubusercontent.com/7823011/206827109-a64ee56d-30aa-4520-ab7c-2826192789fb.mp4

### Checklist
- [x] I have self-reviewed the changes and added explanatory comments as needed


---

**Side notes**

Learned new things while working on this.
- winbox = good ui, good animation, good abstraction
- react-winbox = good abstraction
- #TIL: new technique: quickly add svg by adding url: https://icongr.am/feather/calendar.svg?size=128&color=ffffff

Can also use the icon in GH readme (well, it's just svg!). Example:
<img src="https://icongr.am/clarity/accessibility-2.svg?size=50&color=858585" /><img src="https://icongr.am/devicon/javascript-original.svg?size=50" /><img src="https://icongr.am/jam/android.svg?size=50"/>
